### PR TITLE
Add template for showing the use of estimateFieldSourceAndConfidence

### DIFF
--- a/analyzer_templates/invoice_field_source.json
+++ b/analyzer_templates/invoice_field_source.json
@@ -1,0 +1,36 @@
+{
+  "description": "Sample invoice analyzer",
+  "baseAnalyzerId": "prebuilt-documentAnalyzer",
+  "config": {
+    "returnDetails": true,
+    "estimateFieldSourceAndConfidence": true
+  },
+  "fieldSchema": {
+    "fields": {
+      "VendorName": {
+        "type": "string",
+        "method": "extract",
+        "description": "Vendor issuing the invoice"
+      },
+      "Items": {
+        "type": "array",
+        "method": "extract",
+        "items": {
+          "type": "object",
+          "properties": {
+            "Description": {
+              "type": "string",
+              "method": "extract",
+              "description": "Description of the item"
+            },
+            "Amount": {
+              "type": "number",
+              "method": "extract",
+              "description": "Amount of the item"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/notebooks/field_extraction.ipynb
+++ b/notebooks/field_extraction.ipynb
@@ -55,10 +55,20 @@
    "outputs": [],
    "source": [
     "extraction_templates = {\n",
-    "    \"invoice\":            ('../analyzer_templates/invoice.json',         '../data/invoice.pdf'            ),\n",
-    "    \"call_recording\":     ('../analyzer_templates/call_recording_analytics.json', '../data/callCenterRecording.mp3'),\n",
+    "    # Extract fields from invoices (no grounding sources or confidence scores).\n",
+    "    \"invoice\": ('../analyzer_templates/invoice.json', '../data/invoice.pdf'),\n",
+    "\n",
+    "    # Extract fields from invoices, including grounding sources and confidence scores (optional add-on).\n",
+    "    \"invoice_field_source\": ('../analyzer_templates/invoice_field_source.json', '../data/invoice.pdf'),\n",
+    "\n",
+    "    # Extract insights from call recordings (e.g., summary, topics, mentioned companies, and people).\n",
+    "    \"call_recording\": ('../analyzer_templates/call_recording_analytics.json', '../data/callCenterRecording.mp3'),\n",
+    "\n",
+    "    # Extract summary and sentiment from conversation audio (e.g., customer service calls).\n",
     "    \"conversation_audio\": ('../analyzer_templates/conversational_audio_analytics.json', '../data/callCenterRecording.mp3'),\n",
-    "    \"marketing_video\":    ('../analyzer_templates/marketing_video.json', '../data/FlightSimulator.mp4'              )\n",
+    "\n",
+    "    # Extract descriptions and sentiment analysis from marketing videos.\n",
+    "    \"marketing_video\": ('../analyzer_templates/marketing_video.json', '../data/FlightSimulator.mp4'),\n",
     "}"
    ]
   },


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Add a template in field_extraction notebook to show the use of `estimateFieldSourceAndConfidence` in the `invoice_field_source.json` analyzer template. This is a new 2025-05-01-preview change to provide grounding source and estimated confidence

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Tested in local environment

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
* ...

## Other Information
