### PR TITLE
fix(di-to-cu): drop unsupported field types and normalize time values

### DIFF
--- a/python/di_to_cu_migration_tool/constants.py
+++ b/python/di_to_cu_migration_tool/constants.py
@@ -33,11 +33,20 @@ SUPPORT_FIELD_TYPE = [
     "boolean",
 ]
 
+# Map from DI-only field types to their CU-supported equivalents.
+# CU's ContentFieldType only supports: string, date, time, number, integer, boolean, array, object.
+# All other DI types (selectionMark, currency, phoneNumber, address, signature) must be coerced
+# to a supported type before the analyzer/labels are emitted.
 CONVERT_TYPE_MAP = {
     "selectionMark": "boolean",
     "currency": "number",
+    "phoneNumber": "string",  # CU has no phoneNumber type
+    "address": "string",      # CU has no address type
 }
 
+# Map from DI field types to their DI value-key names. Used to strip DI-specific
+# value keys (e.g., valuePhoneNumber, valueAddress) from labels during type coercion.
+# Do not treat this as the CU spec; see VALID_CU_FIELD_TYPES for that.
 FIELD_VALUE_MAP = {
     "number": "valueNumber",
     "integer": "valueInteger",
@@ -55,11 +64,12 @@ CHECKED_SYMBOL = "☒"
 UNCHECKED_SYMBOL = "☐"
 
 # for CU conversion
-# spec for valid field types
+# spec for valid CU field types. phoneNumber and address are intentionally omitted
+# because CU's ContentFieldType union does not include them; they must be coerced
+# to "string" via CONVERT_TYPE_MAP before emission.
 VALID_CU_FIELD_TYPES = {
     "string": "valueString",
     "date": "valueDate",
-    "phoneNumber": "valuePhoneNumber",
     "integer": "valueInteger",
     "number": "valueNumber",
     "array": "valueArray",
@@ -72,3 +82,14 @@ VALID_CU_FIELD_TYPES = {
 DATE_FORMATS_SLASHED = ["%d/%m/%y", "%m/%d/%y", "%y/%m/%d","%d/%m/%Y", "%m/%d/%Y", "%Y/%m/%d"] # %Y is for 4-year format (Ex: 2015) and %y is for 2-year format (Ex: 15)
 DATE_FORMATS_DASHED = ["%d-%m-%y", "%m-%d-%y", "%y-%m-%d","%d-%m-%Y", "%m-%d-%Y", "%Y-%m-%d"] # can have dashes, instead of slashes
 COMPLETE_DATE_FORMATS = DATE_FORMATS_SLASHED + DATE_FORMATS_DASHED # combine the two formats
+
+# Time formats DI may produce. CU requires ISO 8601 hh:mm:ss.
+# The first format that parses wins; dateutil.parser is used as a final fallback.
+TIME_FORMATS = [
+    "%H:%M:%S",     # 15:30:45 (already ISO)
+    "%H:%M",        # 15:30
+    "%I:%M:%S %p",  # 03:30:45 PM
+    "%I:%M %p",     # 03:30 PM
+    "%I %p",        # 3 PM
+    "%H:%M:%S.%f",  # 15:30:45.123
+]

--- a/python/di_to_cu_migration_tool/cu_converter_generative.py
+++ b/python/di_to_cu_migration_tool/cu_converter_generative.py
@@ -11,7 +11,7 @@ from typing import Optional, Tuple
 from rich import print  # For colored output
 
 # imports from same project
-from constants import CU_API_VERSION, MAX_FIELD_LENGTH, VALID_CU_FIELD_TYPES, COMPLETION_DEPLOYMENT, EMBEDDING_DEPLOYMENT
+from constants import CONVERT_TYPE_MAP, CU_API_VERSION, MAX_FIELD_LENGTH, TIME_FORMATS, VALID_CU_FIELD_TYPES, COMPLETION_DEPLOYMENT, EMBEDDING_DEPLOYMENT
 from field_definitions import FieldDefinitions
 from field_name_utils import FieldNameNormalizer
 
@@ -277,6 +277,27 @@ def convert_di_labels_to_cu(di_labels_path: Path, target_dir: Path, field_name_n
 
     print(f"[green]Successfully converted Document Intelligence labels.json to Content Understanding labels.json at {cu_labels_path}[/green]\n")
 
+def _normalize_time_string(time_string: str) -> Optional[str]:
+    """
+    Best-effort normalization of a raw time string to ISO 8601 (HH:MM:SS).
+    Args:
+        time_string (str): The raw time string, e.g. "3:15 PM", "15:30", "05:32:20".
+    Returns:
+        Optional[str]: The normalized ISO 8601 time, or None if parsing failed.
+    """
+    if not time_string:
+        return None
+    candidate = time_string.strip()
+    for fmt in TIME_FORMATS:
+        try:
+            return datetime.strptime(candidate, fmt).strftime("%H:%M:%S")
+        except ValueError:
+            continue
+    try:
+        return parse(candidate).time().strftime("%H:%M:%S")
+    except Exception:
+        return None
+
 def recursive_convert_di_label_to_cu_helper(value: dict, field_name_normalizer: FieldNameNormalizer = None) -> dict:
     """
     Recursively convert each DI field to CU labels.json format
@@ -288,6 +309,11 @@ def recursive_convert_di_label_to_cu_helper(value: dict, field_name_normalizer: 
     """
     
     value_type = value.get("type")
+    # Defensive coercion: DI types that CU does not support (phoneNumber, address, currency)
+    # should be mapped to their CU-supported equivalents. The field-level pre-conversion
+    # handles the common top-level case, but nested labels may bypass it.
+    if value_type in CONVERT_TYPE_MAP:
+        value_type = CONVERT_TYPE_MAP[value_type]
     if(value_type not in VALID_CU_FIELD_TYPES and value_type != "selectionMark"):
         print(f"[red]Unexpected field type: {value_type}. Please refer to the specification for valid field types.[/red]")
         sys.exit(1)
@@ -314,8 +340,14 @@ def recursive_convert_di_label_to_cu_helper(value: dict, field_name_normalizer: 
             di_label["valueObject"][normalized_key] = recursive_convert_di_label_to_cu_helper(item, field_name_normalizer)
     else:
         value_part = VALID_CU_FIELD_TYPES[value_type]
-        if value.get(value_part) is not None and value.get(value_part) != "":
-            di_label[value_part] = value.get(value_part)
+        raw_value = value.get(value_part)
+        if raw_value is not None and raw_value != "":
+            if value_type == "time":
+                # CU requires ISO 8601 (HH:MM:SS); normalize whatever DI provided.
+                normalized = _normalize_time_string(raw_value)
+                di_label[value_part] = normalized if normalized is not None else raw_value
+            else:
+                di_label[value_part] = raw_value
         else:
             if value_type == "date":
                 date_string = value.get("content")
@@ -333,6 +365,10 @@ def recursive_convert_di_label_to_cu_helper(value: dict, field_name_normalizer: 
                         continue
                 if not finished_date_normalization:
                     di_label["valueDate"] = date_string # going with the default
+            elif value_type == "time":
+                time_string = value.get("content")
+                normalized = _normalize_time_string(time_string)
+                di_label["valueTime"] = normalized if normalized is not None else time_string
             elif value_type == "number":
                 try:
                     content_val = value.get("content")

--- a/python/di_to_cu_migration_tool/cu_converter_neural.py
+++ b/python/di_to_cu_migration_tool/cu_converter_neural.py
@@ -11,7 +11,7 @@ from typing import Optional, Tuple
 from rich import print  # For colored output
 
 # imports from same project
-from constants import COMPLETE_DATE_FORMATS, CU_API_VERSION, MAX_FIELD_LENGTH, VALID_CU_FIELD_TYPES, COMPLETION_DEPLOYMENT, EMBEDDING_DEPLOYMENT, ANALYZER_JSON
+from constants import COMPLETE_DATE_FORMATS, CONVERT_TYPE_MAP, CU_API_VERSION, MAX_FIELD_LENGTH, TIME_FORMATS, VALID_CU_FIELD_TYPES, COMPLETION_DEPLOYMENT, EMBEDDING_DEPLOYMENT, ANALYZER_JSON
 from field_definitions import FieldDefinitions
 from field_name_utils import FieldNameNormalizer
 
@@ -442,6 +442,11 @@ def creating_cu_label_for_neural(label:dict, label_type: str) -> dict:
     Returns:
         dict: The converted CU label.
     """
+    # Defensive coercion: DI types that CU does not support (phoneNumber, address, currency)
+    # must be mapped to their CU-supported equivalents. The field-level pre-conversion in
+    # update_fott_fields handles most cases, but nested column types may bypass it.
+    if label_type in CONVERT_TYPE_MAP:
+        label_type = CONVERT_TYPE_MAP[label_type]
     label_value = VALID_CU_FIELD_TYPES[label_type]
     label_spans = label.get("spans", [])
     label_confidence = label.get("confidence", None)
@@ -524,6 +529,22 @@ def creating_cu_label_for_neural(label:dict, label_type: str) -> dict:
                     continue
             if not finished_date_normalization:
                 final_content = original_date # going with the default
+    elif label_type == "time":
+        # CU requires ISO 8601 (HH:MM:SS); DI can emit raw values like "3:15 PM" or "15:30".
+        original_time = final_content
+        normalized_time = None
+        for fmt in TIME_FORMATS:
+            try:
+                normalized_time = datetime.strptime(original_time, fmt).strftime("%H:%M:%S")
+                break # going with the first format that works
+            except ValueError:
+                continue
+        if normalized_time is None:
+            try:
+                normalized_time = parse(original_time).time().strftime("%H:%M:%S")
+            except Exception:
+                normalized_time = original_time # going with the default
+        final_content = normalized_time
 
     # Convert bounding_regions to source
     sources = []

--- a/python/di_to_cu_migration_tool/tests/test_converter.py
+++ b/python/di_to_cu_migration_tool/tests/test_converter.py
@@ -125,6 +125,202 @@ class TestFieldTypeConversion:
         
         assert converted["fields"][0]["fieldType"] == "number"
 
+    def test_phone_number_to_string(self):
+        """Test that phoneNumber is converted to string (CU has no phoneNumber type)."""
+        fields_data = {
+            "$schema": "https://schema.cognitiveservices.azure.com/formrecognizer/2021-03-01/fields.json",
+            "fields": [
+                {"fieldKey": "phone", "fieldType": "phoneNumber", "fieldFormat": "not-specified"},
+            ]
+        }
+
+        _, converted = update_fott_fields(fields_data)
+
+        assert converted["fields"][0]["fieldType"] == "string"
+
+    def test_address_to_string(self):
+        """Test that address is converted to string (CU has no address type)."""
+        fields_data = {
+            "$schema": "https://schema.cognitiveservices.azure.com/formrecognizer/2021-03-01/fields.json",
+            "fields": [
+                {"fieldKey": "mailingAddress", "fieldType": "address", "fieldFormat": "not-specified"},
+            ]
+        }
+
+        _, converted = update_fott_fields(fields_data)
+
+        assert converted["fields"][0]["fieldType"] == "string"
+
+
+class TestUnsupportedCuTypesRejection:
+    """Tests that the CU converters never emit phoneNumber or address types/values."""
+
+    def test_valid_cu_field_types_excludes_phone_number(self):
+        """VALID_CU_FIELD_TYPES must not include phoneNumber (not in CU's ContentFieldType)."""
+        from constants import VALID_CU_FIELD_TYPES
+
+        assert "phoneNumber" not in VALID_CU_FIELD_TYPES, \
+            "phoneNumber is not part of the CU ContentFieldType union"
+        assert "address" not in VALID_CU_FIELD_TYPES, \
+            "address is not part of the CU ContentFieldType union"
+
+    def test_generative_label_coerces_phone_number_to_string(self):
+        """recursive_convert_di_label_to_cu_helper must never emit valuePhoneNumber."""
+        from cu_converter_generative import recursive_convert_di_label_to_cu_helper
+
+        di_label = {
+            "type": "phoneNumber",
+            "valuePhoneNumber": "+15551234567",
+            "content": "555-123-4567",
+            "spans": [],
+            "boundingRegions": [],
+        }
+
+        cu_label = recursive_convert_di_label_to_cu_helper(di_label)
+
+        assert cu_label["type"] == "string", "phoneNumber label must become string"
+        assert "valuePhoneNumber" not in cu_label
+        assert cu_label["valueString"] == "555-123-4567"
+
+    def test_generative_label_coerces_address_to_string(self):
+        """recursive_convert_di_label_to_cu_helper must never emit valueAddress."""
+        from cu_converter_generative import recursive_convert_di_label_to_cu_helper
+
+        di_label = {
+            "type": "address",
+            "valueAddress": {"streetAddress": "1 Microsoft Way"},
+            "content": "1 Microsoft Way, Redmond WA",
+            "spans": [],
+            "boundingRegions": [],
+        }
+
+        cu_label = recursive_convert_di_label_to_cu_helper(di_label)
+
+        assert cu_label["type"] == "string", "address label must become string"
+        assert "valueAddress" not in cu_label
+        assert cu_label["valueString"] == "1 Microsoft Way, Redmond WA"
+
+    def test_neural_label_coerces_phone_number_to_string(self):
+        """creating_cu_label_for_neural must never emit valuePhoneNumber."""
+        from cu_converter_neural import creating_cu_label_for_neural
+
+        di_label = {
+            "value": [{"page": 1, "text": "555-123-4567", "boundingBoxes": [[0.0]*8]}],
+            "spans": [],
+        }
+
+        cu_label = creating_cu_label_for_neural(di_label, "phoneNumber")
+
+        assert cu_label["type"] == "string", "phoneNumber label must become string"
+        assert "valuePhoneNumber" not in cu_label
+        assert cu_label["valueString"] == "555-123-4567"
+
+    def test_neural_label_coerces_address_to_string(self):
+        """creating_cu_label_for_neural must never emit valueAddress."""
+        from cu_converter_neural import creating_cu_label_for_neural
+
+        di_label = {
+            "value": [{"page": 1, "text": "1 Microsoft Way", "boundingBoxes": [[0.0]*8]}],
+            "spans": [],
+        }
+
+        cu_label = creating_cu_label_for_neural(di_label, "address")
+
+        assert cu_label["type"] == "string", "address label must become string"
+        assert "valueAddress" not in cu_label
+        assert cu_label["valueString"] == "1 Microsoft Way"
+
+
+class TestTimeNormalization:
+    """Tests that DI time values are normalized to CU's required ISO 8601 (HH:MM:SS)."""
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("05:32:20", "05:32:20"),        # already ISO
+        ("15:30", "15:30:00"),           # 24-hour, no seconds
+        ("3:15 PM", "15:15:00"),         # 12-hour with meridiem
+        ("03:15 AM", "03:15:00"),        # 12-hour with leading zero
+        ("11:45:30 PM", "23:45:30"),     # 12-hour with seconds
+    ])
+    def test_generative_time_content_normalized(self, raw, expected):
+        """Generative converter normalizes raw time content to HH:MM:SS."""
+        from cu_converter_generative import recursive_convert_di_label_to_cu_helper
+
+        di_label = {
+            "type": "time",
+            "content": raw,
+            "spans": [],
+            "boundingRegions": [],
+        }
+
+        cu_label = recursive_convert_di_label_to_cu_helper(di_label)
+
+        assert cu_label["type"] == "time"
+        assert cu_label["valueTime"] == expected
+
+    def test_generative_time_value_time_normalized(self):
+        """Even when DI provides valueTime, the generative converter normalizes it."""
+        from cu_converter_generative import recursive_convert_di_label_to_cu_helper
+
+        di_label = {
+            "type": "time",
+            "valueTime": "3:15 PM",  # DI occasionally emits non-ISO
+            "content": "3:15 PM",
+            "spans": [],
+            "boundingRegions": [],
+        }
+
+        cu_label = recursive_convert_di_label_to_cu_helper(di_label)
+
+        assert cu_label["valueTime"] == "15:15:00"
+
+    def test_generative_time_unparseable_falls_back(self):
+        """Unparseable time strings fall back to the raw content."""
+        from cu_converter_generative import recursive_convert_di_label_to_cu_helper
+
+        di_label = {
+            "type": "time",
+            "content": "not-a-time",
+            "spans": [],
+            "boundingRegions": [],
+        }
+
+        cu_label = recursive_convert_di_label_to_cu_helper(di_label)
+
+        assert cu_label["valueTime"] == "not-a-time"
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("05:32:20", "05:32:20"),
+        ("15:30", "15:30:00"),
+        ("3:15 PM", "15:15:00"),
+        ("11:45:30 PM", "23:45:30"),
+    ])
+    def test_neural_time_content_normalized(self, raw, expected):
+        """Neural converter normalizes DI text to HH:MM:SS."""
+        from cu_converter_neural import creating_cu_label_for_neural
+
+        di_label = {
+            "value": [{"page": 1, "text": raw, "boundingBoxes": [[0.0]*8]}],
+            "spans": [],
+        }
+
+        cu_label = creating_cu_label_for_neural(di_label, "time")
+
+        assert cu_label["type"] == "time"
+        assert cu_label["valueTime"] == expected
+
+    def test_neural_time_unparseable_falls_back(self):
+        """Neural converter falls back to raw content when time is unparseable."""
+        from cu_converter_neural import creating_cu_label_for_neural
+
+        di_label = {
+            "value": [{"page": 1, "text": "not-a-time", "boundingBoxes": [[0.0]*8]}],
+            "spans": [],
+        }
+
+        cu_label = creating_cu_label_for_neural(di_label, "time")
+
+        assert cu_label["valueTime"] == "not-a-time"
+
 
 class TestFieldNameValidation:
     """Tests for field name validation."""


### PR DESCRIPTION
## Summary

Fixes two correctness issues in the DI-to-CU migration tool where converter output could violate CU's `ContentFieldType` contract.

CU's [`ContentFieldType`](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/ai/ContentUnderstanding/models.tsp) union supports only `string`, `date`, `time`, `number`, `integer`, `boolean`, `array`, `object`. DI's field types are broader.

## Problem 1 — `valuePhoneNumber` and `valueAddress` leaked to CU

`phoneNumber` was listed in `VALID_CU_FIELD_TYPES`, and neither `phoneNumber` nor `address` had entries in `CONVERT_TYPE_MAP`. Top-level fields were mostly caught by `update_fott_fields`, but nested labels (array items, object properties) bypassed that pre-conversion and emitted DI-only value keys (`valuePhoneNumber`, `valueAddress`) that CU rejects.

## Problem 2 — no `time` normalization

The converters had a `date` normalization branch producing ISO 8601 `YYYY-MM-DD`, but no matching branch for `time` (CU requires ISO 8601 `HH:MM:SS`). Raw values like `"3:15 PM"` or `"15:30"` were passed through as-is.

## Changes

- **`constants.py`** — Added `phoneNumber → string` and `address → string` to `CONVERT_TYPE_MAP`. Removed `phoneNumber` from `VALID_CU_FIELD_TYPES`. Added a `TIME_FORMATS` list for parsing.
- **`cu_converter_generative.py`** — Added `_normalize_time_string()` helper. Added defensive coercion in `recursive_convert_di_label_to_cu_helper` so any DI-only type is remapped before dispatch. Added `time` normalization for both the `valueTime`-present path and the content-fallback path.
- **`cu_converter_neural.py`** — Mirrored the defensive coercion in `creating_cu_label_for_neural`. Added a `time` normalization branch alongside the existing `date` branch.
- **`tests/test_converter.py`** — Added 19 tests:
  - `TestUnsupportedCuTypesRejection` — verifies `VALID_CU_FIELD_TYPES` excludes phoneNumber/address, and both converters coerce phoneNumber/address labels to string (no `valuePhoneNumber`/`valueAddress` in output).
  - `TestTimeNormalization` — parametrized coverage of ISO passthrough, 24-hour without seconds, 12-hour AM/PM, and unparseable fallback for both converters.
  - Plus `phoneNumber`/`address` cases in `TestFieldTypeConversion`.

## Verification

```
cd python/di_to_cu_migration_tool/tests
pytest test_converter.py -v
```

**71 passed** (52 existing + 19 new).